### PR TITLE
LOG-2415: Data-Sink-Client: add newlines when posting data

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ retry_backoff_factor: 2
 adapter: :excon
 read_timeout: 5
 open_timeout: 5
+add_newlines: true
 ```
 
 or pass a Faraday client yourself with `client:`.

--- a/lib/data-sink-client/version.rb
+++ b/lib/data-sink-client/version.rb
@@ -1,3 +1,3 @@
 module DataSinkClient
-  VERSION = '0.1.2'.freeze
+  VERSION = '0.2.0'.freeze
 end

--- a/lib/data_sink/client.rb
+++ b/lib/data_sink/client.rb
@@ -11,6 +11,7 @@ module DataSink
       adapter: :excon,
       read_timeout: 5,
       open_timeout: 5,
+      add_newlines: true
     }.freeze
 
     attr_reader :client, :options
@@ -23,7 +24,7 @@ module DataSink
     end
 
     def post(stream_id, body)
-      post_gzipped(stream_id, gzip(body))
+      post_gzipped(stream_id, gzip(transform(body)))
     end
 
     def post_gzipped(stream_id, body)
@@ -49,6 +50,14 @@ module DataSink
         f.adapter options[:adapter]
       end.tap do |client|
         client.basic_auth(user, pass)
+      end
+    end
+
+    def transform(body)
+      if options[:add_newlines]
+        body + "\n"
+      else
+        body
       end
     end
 

--- a/spec/data_sink/client_spec.rb
+++ b/spec/data_sink/client_spec.rb
@@ -75,7 +75,7 @@ describe DataSink::Client do
     end
 
     describe 'post' do
-      let(:compressed_body) { gzip(body) }
+      let(:compressed_body) { gzip(body+"\n") }
 
       let(:perform) { subject.post(stream_id, body) }
 
@@ -83,6 +83,17 @@ describe DataSink::Client do
         perform
         expect(WebMock).to have_requested(:post, "#{url}/#{endpoint}").
           with(body: compressed_body, headers: {'Content-Encoding' => 'application/gzip'})
+      end
+
+      context 'when add_newlines is false' do
+        let(:options) { super().merge(add_newlines: false) }
+        let(:compressed_body) { gzip(body) }
+
+        it 'posts the body without newlines' do
+          perform
+          expect(WebMock).to have_requested(:post, "#{url}/#{endpoint}").
+            with(body: compressed_body, headers: {'Content-Encoding' => 'application/gzip'})
+        end
       end
     end
   end


### PR DESCRIPTION
Tested with dispatcher on staging

===

Jira story [#LOG-2415](https://deliveroo.atlassian.net/browse/LOG-2415) in project *Logistics*:

> The direct Firehose-Kinesis bridge doesn't add newlines after each item. This makes it somehow more difficult to parse the resulting files.
> 
> Add the option to add newlines from the data-sink-client.