### PR TITLE
LOG-XXX update excon version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: .
   specs:
-    data-sink-client (0.2.1)
-      excon (~> 0.55.0)
+    data-sink-client (0.2.2)
+      excon (~> 0.71)
       faraday (> 0.10.0)
 
 GEM
@@ -13,11 +13,11 @@ GEM
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     diff-lcs (1.3)
-    excon (0.55.0)
-    faraday (0.15.0)
+    excon (0.73.0)
+    faraday (1.0.1)
       multipart-post (>= 1.2, < 3)
     hashdiff (0.3.0)
-    multipart-post (2.0.0)
+    multipart-post (2.1.1)
     public_suffix (2.0.4)
     rake (10.5.0)
     rspec (3.5.0)
@@ -50,4 +50,4 @@ DEPENDENCIES
   webmock (~> 2.1)
 
 BUNDLED WITH
-   1.16.1
+   1.16.2

--- a/data-sink-client.gemspec
+++ b/data-sink-client.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency 'faraday', '> 0.10.0'
-  spec.add_dependency 'excon', '~> 0.55.0'
+  spec.add_dependency 'excon', '~> 0.71'
 
   spec.add_development_dependency "bundler", "~> 1.13"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/lib/data-sink-client/version.rb
+++ b/lib/data-sink-client/version.rb
@@ -1,3 +1,3 @@
 module DataSinkClient
-  VERSION = '0.2.1'.freeze
+  VERSION = '0.2.2'.freeze
 end


### PR DESCRIPTION
We have a few security vulnerability alerts on Dispatcher. One of them is excon but we are unable to update to >0.71 because of this dependancy. 