### PR TITLE
Bump versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,4 @@ sudo: false
 language: ruby
 rvm:
   - 2.2.5
-before_install: gem install bundler -v 1.13.2
+before_install: gem install bundler -v 2.3.7

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,52 +2,74 @@ PATH
   remote: .
   specs:
     data-sink-client (0.2.1)
-      excon (~> 0.55.0)
-      faraday (> 0.10.0)
+      excon (~> 0.92)
+      faraday (~> 1.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.5.0)
-      public_suffix (~> 2.0, >= 2.0.2)
-    crack (0.4.3)
-      safe_yaml (~> 1.0.0)
-    diff-lcs (1.3)
-    excon (0.55.0)
-    faraday (0.15.0)
+    addressable (2.8.0)
+      public_suffix (>= 2.0.2, < 5.0)
+    crack (0.4.5)
+      rexml
+    diff-lcs (1.5.0)
+    excon (0.92.3)
+    faraday (1.10.0)
+      faraday-em_http (~> 1.0)
+      faraday-em_synchrony (~> 1.0)
+      faraday-excon (~> 1.1)
+      faraday-httpclient (~> 1.0)
+      faraday-multipart (~> 1.0)
+      faraday-net_http (~> 1.0)
+      faraday-net_http_persistent (~> 1.0)
+      faraday-patron (~> 1.0)
+      faraday-rack (~> 1.0)
+      faraday-retry (~> 1.0)
+      ruby2_keywords (>= 0.0.4)
+    faraday-em_http (1.0.0)
+    faraday-em_synchrony (1.0.0)
+    faraday-excon (1.1.0)
+    faraday-httpclient (1.0.1)
+    faraday-multipart (1.0.3)
       multipart-post (>= 1.2, < 3)
-    hashdiff (0.3.0)
-    multipart-post (2.0.0)
-    public_suffix (2.0.4)
+    faraday-net_http (1.0.1)
+    faraday-net_http_persistent (1.2.0)
+    faraday-patron (1.0.0)
+    faraday-rack (1.0.0)
+    faraday-retry (1.0.3)
+    hashdiff (1.0.1)
+    multipart-post (2.1.1)
+    public_suffix (4.0.7)
     rake (10.5.0)
-    rspec (3.5.0)
-      rspec-core (~> 3.5.0)
-      rspec-expectations (~> 3.5.0)
-      rspec-mocks (~> 3.5.0)
-    rspec-core (3.5.4)
-      rspec-support (~> 3.5.0)
-    rspec-expectations (3.5.0)
+    rexml (3.2.5)
+    rspec (3.11.0)
+      rspec-core (~> 3.11.0)
+      rspec-expectations (~> 3.11.0)
+      rspec-mocks (~> 3.11.0)
+    rspec-core (3.11.0)
+      rspec-support (~> 3.11.0)
+    rspec-expectations (3.11.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.5.0)
-    rspec-mocks (3.5.0)
+      rspec-support (~> 3.11.0)
+    rspec-mocks (3.11.1)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.5.0)
-    rspec-support (3.5.0)
-    safe_yaml (1.0.4)
-    webmock (2.1.0)
+      rspec-support (~> 3.11.0)
+    rspec-support (3.11.0)
+    ruby2_keywords (0.0.5)
+    webmock (2.3.2)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff
 
 PLATFORMS
-  ruby
+  x86_64-darwin-21
 
 DEPENDENCIES
-  bundler (~> 1.13)
+  bundler (~> 2.0)
   data-sink-client!
   rake (~> 10.0)
   rspec (~> 3.0)
   webmock (~> 2.1)
 
 BUNDLED WITH
-   1.16.1
+   2.3.7

--- a/data-sink-client.gemspec
+++ b/data-sink-client.gemspec
@@ -21,10 +21,10 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'faraday', '> 0.10.0'
-  spec.add_dependency 'excon', '~> 0.55.0'
+  spec.add_dependency 'faraday', '~> 1.0'
+  spec.add_dependency 'excon', '~> 0.92'
 
-  spec.add_development_dependency "bundler", "~> 1.13"
+  spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "webmock", "~> 2.1"

--- a/lib/data_sink/client.rb
+++ b/lib/data_sink/client.rb
@@ -50,7 +50,7 @@ module DataSink
         f.options.open_timeout = options[:open_timeout] if options[:open_timeout]
         f.adapter options[:adapter]
       end.tap do |client|
-        client.basic_auth(user, pass)
+        client.request(:basic_auth, user, pass)
       end
     end
 


### PR DESCRIPTION
- `fog-aws` that runs on ruby 3 requires `excon` 0.58, which clashed with this gem's requirements
- `faraday` was extremely old (v2.2.0 was released this year!)
- Bumped `bundler` gem, to fit with ruby 3 as well.